### PR TITLE
Update for app transport

### DIFF
--- a/InternetMonitor/Info.plist
+++ b/InternetMonitor/Info.plist
@@ -30,5 +30,10 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-</dict>
+        <key>NSAppTransportSecurity</key>
+	<dict>
+	<key>NSAllowsArbitraryLoads</key>
+	<true/>
+	</dict>
+	</dict>
 </plist>


### PR DESCRIPTION
This is the simplest fix for #1 .. you can also only whitelist `http://speedtest.wdc01.softlayer.com`

Cheers
